### PR TITLE
fix issue with QuerySingleAsync and string

### DIFF
--- a/Moq.Dapper.Test/DapperQueryAsyncTest.cs
+++ b/Moq.Dapper.Test/DapperQueryAsyncTest.cs
@@ -59,6 +59,21 @@ namespace Moq.Dapper.Test
 
             Assert.AreEqual(actual, expected);
         }
+        
+        [Test]
+        public void QuerySingleAsyncGenericWithString()
+        {
+            var connection = new Mock<DbConnection>();
+
+            var expected = "toto";
+
+            connection.SetupDapperAsync(c => c.QuerySingleAsync<string>(It.IsAny<string>(), null, null, null, null))
+                      .ReturnsAsync(expected);
+
+            var actual = connection.Object.QuerySingleAsync<string>("").GetAwaiter().GetResult();
+
+            Assert.AreEqual(actual, expected);
+        }
 
         [Test]
         public void QuerySingleAsyncGenericUsingDbConnectionInterface()

--- a/Moq.Dapper/ObjectExtensions.cs
+++ b/Moq.Dapper/ObjectExtensions.cs
@@ -8,7 +8,7 @@ namespace Moq.Dapper
     static class ObjectExtensions
     {
          internal static DataTable ToDataTable(this object result, Type resultType) =>
-             result is IEnumerable results ?
+             result is IEnumerable results and not string ?
              results.ToDataTable(resultType.GenericTypeArguments.Single()) :
              new[] { result }.ToDataTable(resultType);
     }


### PR DESCRIPTION
Hi guy,

I was dealing the same issue as you with the repo of UnoSD which is not up-to-date, so instead of creating my own nuget I prefers contribute to your fork which has already been packaged to nuget.org.

This contribution fix QuerySingleAsync<string> which currently failed because string is an IEnumerable type.

Thank you if you take the time to review and merge this pull request.